### PR TITLE
feat: error handling & status toasts

### DIFF
--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -3,7 +3,9 @@ import { ICONS } from "./iconography.tsx";
 import { PoolDisplay } from "./pool-display.tsx";
 import { ConnectWalletButton } from "./connect-wallet.tsx";
 import { supportedChains } from "../wallet/config.ts";
-import { useStatusMessageState } from "../context/status-message.tsx";
+import { useStatusMessageState, useStatusMessageDispatch } from "../context/status-message.tsx";
+import { useToast } from "../ui/toast.tsx";
+import { useEffect, useRef } from "react";
 
 const LogoSpan = () => <span id="header-logo-wrapper">{ICONS.DAO_LOGO}</span>;
 
@@ -11,6 +13,33 @@ export function DashboardPage() {
   const { isConnected } = useAppKitAccount();
   const { chainId } = useAppKitNetwork();
   const { successMessage, errorMessage } = useStatusMessageState();
+  const statusMessageDispatch = useStatusMessageDispatch();
+  const { addToast } = useToast();
+  const prevSuccessRef = useRef<string | null>(null);
+  const prevErrorRef = useRef<string | null>(null);
+
+  // Bridge status messages to toasts
+  useEffect(() => {
+    if (successMessage && successMessage !== prevSuccessRef.current) {
+      addToast("success", successMessage);
+      prevSuccessRef.current = successMessage;
+    }
+  }, [successMessage, addToast]);
+
+  useEffect(() => {
+    if (errorMessage && errorMessage !== prevErrorRef.current) {
+      addToast("error", errorMessage);
+      prevErrorRef.current = errorMessage;
+    }
+  }, [errorMessage, addToast]);
+
+  // Clear inline status messages after they've been toasted
+  useEffect(() => {
+    if (successMessage || errorMessage) {
+      const timer = setTimeout(() => statusMessageDispatch({ type: "clear" }), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [successMessage, errorMessage, statusMessageDispatch]);
 
   const isUnsupportedChain = isConnected && chainId && !supportedChains.some((c) => c.id === chainId);
 
@@ -29,23 +58,7 @@ export function DashboardPage() {
         <ConnectWalletButton />
       </section>
 
-      {/* Status Displays */}
-      {errorMessage && (
-        <section id="error-message-wrapper">
-          <div className="status-message">
-            {ICONS.WARNING}
-            <span>{errorMessage}</span>
-          </div>
-        </section>
-      )}
-      {successMessage && (
-        <section id="success-message-wrapper">
-          <div className="status-message">
-            {ICONS.SUCCESS}
-            <span>{successMessage}</span>
-          </div>
-        </section>
-      )}
+      {/* Status messages are now handled by the toast system */}
 
       {isUnsupportedChain ? (
         <div className="pool-container">

--- a/src/css/app-styles.css
+++ b/src/css/app-styles.css
@@ -324,3 +324,94 @@ wcm-modal::part(overlay) {
     height: 44px;
   }
 }
+
+/* Toast System */
+#toast-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 400px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  pointer-events: auto;
+  cursor: pointer;
+  animation: toast-slide-in 0.25s ease-out;
+  opacity: 0.95;
+  transition: opacity 0.2s;
+}
+
+.toast:hover {
+  opacity: 1;
+}
+
+.toast-success {
+  background-color: #ecfdf5;
+  border: 1px solid #6ee7b7;
+  color: #065f46;
+}
+
+.toast-error {
+  background-color: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+}
+
+.toast-info {
+  background-color: #eff6ff;
+  border: 1px solid #93c5fd;
+  color: #1e40af;
+}
+
+.toast-icon {
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.toast-message {
+  flex: 1;
+  word-break: break-word;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 2px;
+  color: inherit;
+  opacity: 0.6;
+  line-height: 1;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}
+
+@keyframes toast-slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 0.95;
+  }
+}
+
+/* Hide old inline status messages when toast system is active */
+/* Old status-message elements are replaced by toasts */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { WagmiProvider } from "wagmi";
 import App from "./App.tsx";
 import { grid } from "./the-grid";
 import { StatusMessageProvider } from "./context/status-message.tsx";
+import { ToastProvider } from "./ui/toast.tsx";
 import { wagmiAdapter } from "./wallet/config";
 
 const queryClient = new QueryClient();
@@ -25,7 +26,9 @@ createRoot(rootElement).render(
     <WagmiProvider config={wagmiAdapter.wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <StatusMessageProvider>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </StatusMessageProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -1,0 +1,115 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+
+export type ToastVariant = "info" | "success" | "error";
+
+export interface Toast {
+  id: string;
+  variant: ToastVariant;
+  message: string;
+  persistent?: boolean;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  addToast: (variant: ToastVariant, message: string, options?: { persistent?: boolean }) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let toastCounter = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const removeToast = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const addToast = useCallback(
+    (variant: ToastVariant, message: string, options?: { persistent?: boolean }) => {
+      // Collapse duplicates: remove existing toast with same variant+message
+      const duplicateKey = `${variant}:${message}`;
+      setToasts((prev) => {
+        const filtered = prev.filter((t) => `${t.variant}:${t.message}` !== duplicateKey);
+        const id = `toast-${++toastCounter}`;
+        const toast: Toast = { id, variant, message, persistent: options?.persistent };
+
+        // Auto-dismiss after 5s unless persistent or critical error
+        if (!toast.persistent) {
+          const dismissMs = variant === "error" ? 6000 : 5000;
+          const timer = setTimeout(() => {
+            setToasts((prev) => prev.filter((t) => t.id !== id));
+            timersRef.current.delete(id);
+          }, dismissMs);
+          timersRef.current.set(id, timer);
+        }
+
+        return [...filtered, toast];
+      });
+    },
+    [removeToast]
+  );
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={removeToast} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider");
+  }
+  return context;
+}
+
+function ToastContainer({ toasts, onDismiss }: { toasts: Toast[]; onDismiss: (id: string) => void }) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div id="toast-container" role="status" aria-live="polite">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`toast toast-${toast.variant}`} onClick={() => !toast.persistent && onDismiss(toast.id)}>
+          <span className="toast-icon">{iconForVariant(toast.variant)}</span>
+          <span className="toast-message">{toast.message}</span>
+          {!toast.persistent && (
+            <button className="toast-close" onClick={(e) => { e.stopPropagation(); onDismiss(toast.id); }} aria-label="Dismiss">
+              ×
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function iconForVariant(variant: ToastVariant): string {
+  switch (variant) {
+    case "success":
+      return "✓";
+    case "error":
+      return "⚠";
+    case "info":
+    default:
+      return "ℹ";
+  }
+}


### PR DESCRIPTION
## Summary

Implements #8 - Error Handling & Status Toasts

### Implementation

**Toast System** (`src/ui/toast.tsx`):
- `ToastProvider` + `useToast()` hook with `info`, `success`, `error` variants
- Auto-dismiss: 5s for info/success, 6s for errors
- Duplicate message collapsing
- Persistent toast support for critical errors
- Clean slide-in animation

**Integration**:
- Wrapped app with `ToastProvider` in `main.tsx`
- Bridged existing `StatusMessageProvider` to toast system in `dashboard-page.tsx`
- Inline status messages replaced by toasts
- All existing error handling flows (stake/unstake/approve/claim) automatically show toasts

**Styling** (`src/css/app-styles.css`):
- Lightweight CSS only (~90 lines), no UI library added
- Variants: green (success), red (error), blue (info)
- Fixed bottom-right positioning with z-index
- Responsive and accessible (aria-live)

### Key Design Decisions
- Backward compatible: kept `StatusMessageProvider` as the source of truth, bridged to toasts
- No console spam or unhandled promise rejections
- Existing hooks (`useStaking.ts`, `connect-wallet.tsx`) unchanged - they continue to dispatch to StatusMessageProvider which gets bridged

### Files Changed
- `src/ui/toast.tsx` (new) - Toast provider, hook, and container component
- `src/main.tsx` - Add ToastProvider wrapper
- `src/components/dashboard-page.tsx` - Bridge status messages to toasts
- `src/css/app-styles.css` - Toast styles