### PR TITLE
Fix #9: Harden RPC URL resolution and health checks

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -5,6 +5,68 @@
  */
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
+
+export const MAINNET_RPC_FALLBACKS = ["https://rpc.ubq.fi"] as const;
+
 const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+
+export type RpcUrlValidation = {
+  valid: boolean;
+  reason?: string;
+};
+
+export function validateRpcUrl(value: string): RpcUrlValidation {
+  if (!value.trim()) return { valid: false, reason: "RPC URL is empty" };
+
+  if (value.startsWith("/")) return { valid: true };
+
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) {
+      return { valid: false, reason: `RPC URL must use http or https, received ${url.protocol}` };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: false, reason: "RPC URL must be an absolute http(s) URL or a relative path" };
+  }
+}
+
+function warnInvalidRpcUrl(url: string, reason: string) {
+  console.warn(`[rpc] Ignoring invalid VITE_RPC_URL "${url}": ${reason}`);
+}
+
+export function resolveRpcBaseUrl({
+  envRpcUrl,
+  hostname,
+  origin,
+  localNode,
+}: {
+  envRpcUrl?: string;
+  hostname?: string;
+  origin?: string;
+  localNode?: boolean;
+}) {
+  if (localNode) return envRpcUrl || "http://localhost:8545";
+
+  if (envRpcUrl) {
+    const validation = validateRpcUrl(envRpcUrl);
+    if (validation.valid) return envRpcUrl;
+    warnInvalidRpcUrl(envRpcUrl, validation.reason ?? "unknown validation error");
+  }
+
+  if (isDenoDeployHost(hostname ?? "")) return MAINNET_RPC_FALLBACKS[0];
+
+  return `${origin ?? ""}/rpc`;
+}
+
+export function getRpcUrlForChain(baseUrl: string, chainId: number, localNode = isLocalNode) {
+  if (localNode) return baseUrl;
+  return `${baseUrl.replace(/\/$/, "")}/${chainId}`;
+}
+
+export const RPC_URL = resolveRpcBaseUrl({
+  envRpcUrl: import.meta.env.VITE_RPC_URL,
+  hostname: currentLocation?.hostname,
+  origin: currentLocation?.origin,
+  localNode: isLocalNode,
+});

--- a/src/utils/rpc-health.ts
+++ b/src/utils/rpc-health.ts
@@ -1,0 +1,42 @@
+export type RpcHealthStatus = {
+  ok: boolean;
+  url: string;
+  chainId?: number;
+  error?: string;
+  elapsedMs: number;
+};
+
+export async function rpcHealthCheck(url: string, timeoutMs = 1500): Promise<RpcHealthStatus> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return { ok: false, url, error: `HTTP ${response.status}`, elapsedMs: Date.now() - startedAt };
+    }
+
+    const payload = (await response.json()) as { result?: string; error?: { message?: string } };
+    if (payload.error) {
+      return { ok: false, url, error: payload.error.message ?? "RPC returned an error", elapsedMs: Date.now() - startedAt };
+    }
+
+    if (!payload.result) {
+      return { ok: false, url, error: "RPC response did not include chain id", elapsedMs: Date.now() - startedAt };
+    }
+
+    return { ok: true, url, chainId: Number.parseInt(payload.result, 16), elapsedMs: Date.now() - startedAt };
+  } catch (error) {
+    const message = error instanceof Error && error.name === "AbortError" ? `Timed out after ${timeoutMs}ms` : error instanceof Error ? error.message : "Unknown RPC error";
+    return { ok: false, url, error: message, elapsedMs: Date.now() - startedAt };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -1,5 +1,5 @@
 import { mainnet, anvil, type Chain } from "viem/chains";
-import { isLocalNode, RPC_URL } from "../constants/config";
+import { getRpcUrlForChain, isLocalNode, RPC_URL } from "../constants/config";
 import { createConfig, http, injected, type Transport } from "wagmi";
 
 export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [mainnet, anvil] : [mainnet];
@@ -11,7 +11,7 @@ type TransportsMap = Record<ChainId, Transport>;
 const transports = supportedChains.reduce<TransportsMap>((acc, chain) => {
   // In local-node mode, use raw RPC_URL without chain ID suffix for ALL chains
   // In production/dev mode, append chain ID
-  const rpcUrl = isLocalNode ? RPC_URL : `${RPC_URL}/${chain.id}`;
+  const rpcUrl = getRpcUrlForChain(RPC_URL, chain.id, isLocalNode);
 
   acc[chain.id] = http(rpcUrl, {
     batch: isLocalNode ? false : true,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { isDenoDeployHost } from "../src/constants/config";
+import { getRpcUrlForChain, isDenoDeployHost, resolveRpcBaseUrl, validateRpcUrl } from "../src/constants/config";
 
 describe("isDenoDeployHost", () => {
   it("matches Deno Deploy preview hostnames", () => {
@@ -11,5 +11,43 @@ describe("isDenoDeployHost", () => {
   it("does not match unrelated hostnames", () => {
     expect(isDenoDeployHost("stake.ubq.fi")).toBe(false);
     expect(isDenoDeployHost("localhost")).toBe(false);
+  });
+});
+
+describe("validateRpcUrl", () => {
+  it("accepts absolute http(s) URLs and relative paths", () => {
+    expect(validateRpcUrl("https://rpc.ubq.fi").valid).toBe(true);
+    expect(validateRpcUrl("http://localhost:8545").valid).toBe(true);
+    expect(validateRpcUrl("/rpc").valid).toBe(true);
+  });
+
+  it("rejects malformed and unsupported URLs", () => {
+    expect(validateRpcUrl("not a url").valid).toBe(false);
+    expect(validateRpcUrl("ftp://example.com").valid).toBe(false);
+    expect(validateRpcUrl("").valid).toBe(false);
+  });
+});
+
+describe("resolveRpcBaseUrl", () => {
+  it("uses valid VITE_RPC_URL when provided", () => {
+    expect(resolveRpcBaseUrl({ envRpcUrl: "https://example.com/rpc", hostname: "localhost", origin: "http://localhost:5173" })).toBe("https://example.com/rpc");
+  });
+
+  it("falls back to Deno Deploy RPC when env URL is invalid", () => {
+    expect(resolveRpcBaseUrl({ envRpcUrl: "bad url", hostname: "preview.deno.dev", origin: "https://preview.deno.dev" })).toBe("https://rpc.ubq.fi");
+  });
+
+  it("uses localhost RPC in local-node mode without needing env", () => {
+    expect(resolveRpcBaseUrl({ hostname: "localhost", origin: "http://localhost:5173", localNode: true })).toBe("http://localhost:8545");
+  });
+});
+
+describe("getRpcUrlForChain", () => {
+  it("appends chain id outside local-node mode", () => {
+    expect(getRpcUrlForChain("https://rpc.ubq.fi/", 1, false)).toBe("https://rpc.ubq.fi/1");
+  });
+
+  it("does not append chain id in local-node mode", () => {
+    expect(getRpcUrlForChain("http://localhost:8545", 31337, true)).toBe("http://localhost:8545");
   });
 });

--- a/tests/rpc-health.test.ts
+++ b/tests/rpc-health.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+
+import { rpcHealthCheck } from "../src/utils/rpc-health";
+
+describe("rpcHealthCheck", () => {
+  it("returns ok status with parsed chain id", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    try {
+      const result = await rpcHealthCheck("https://rpc.example", 100);
+      expect(result.ok).toBe(true);
+      expect(result.chainId).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns unavailable status for non-200 responses", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("server error", { status: 500 })) as unknown as typeof fetch;
+
+    try {
+      const result = await rpcHealthCheck("https://rpc.example", 100);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("HTTP 500");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Fixes #9

## Summary
- Validate `VITE_RPC_URL` and warn/fallback when it is malformed.
- Preserve local-node behavior by avoiding chain-id suffixing for local RPC URLs.
- Centralize chain-specific RPC URL construction.
- Add `rpcHealthCheck()` utility using `eth_chainId` with abort/timeout handling.
- Add tests for RPC URL validation/resolution and health check success/error paths.

## Validation
- `npm run lint`
- `npx tsc -p tests/tsconfig.json --noEmit`
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm run build`
- `git diff --check`

## AI disclosure
I used AI assistance while working on this PR. I reviewed the generated changes, tested them locally, and am responsible for the submission.

## Note
I did not include the optional dev diagnostic panel to keep the change small and focused.