### PR TITLE
Add Playwright e2e smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,32 @@ cast rpc evm_mine
 
 ## 🔧 Scripts
 
-| Script | Purpose |
-|--------|---------|
-| `bun run dev` | Dev server (MODE=dev) using remote RPC |
-| `bun run local` | Dev server (MODE=local-node) enabling `anvil` chain id 31337 |
-| `bun run build` | Production build to `dist/` |
-| `bun run lint` | ESLint over the repo |
+| Script                     | Purpose                                                      |
+| -------------------------- | ------------------------------------------------------------ |
+| `bun run dev`              | Dev server (MODE=dev) using remote RPC                       |
+| `bun run local`            | Dev server (MODE=local-node) enabling `anvil` chain id 31337 |
+| `bun run build`            | Production build to `dist/`                                  |
+| `bun run lint`             | ESLint over the repo                                         |
+| `bun run e2e`              | Playwright Chromium smoke tests against preview mode         |
+| `E2E_MODE=dev bun run e2e` | Playwright Chromium smoke tests against the Vite dev server  |
+| `bun run e2e:ui`           | Open the Playwright UI runner                                |
+| `bun run preview`          | Serve the production build on port 4173                      |
+
+### End-to-End Smoke Tests
+
+The Playwright smoke suite starts its own server and does not require a wallet,
+RPC key, or chain fork. By default, it builds and serves the production preview
+on <http://127.0.0.1:4173>.
+
+```bash
+bun run e2e
+```
+
+To run the same smoke tests against the Vite dev server:
+
+```bash
+E2E_MODE=dev bun run e2e
+```
 
 ## 🌐 RPC Resolution
 

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -1,6 +1,0 @@
-import { expect, test } from "@playwright/test";
-
-test("renders landing page", async ({ page }) => {
-  await page.goto("/");
-  await expect(page.locator("body")).toBeVisible();
-});

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "bun test",
-    "test:e2e": "bun x playwright test"
+    "test": "bun test tests/*.test.ts",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "preview": "vite preview --port 4173",
+    "test:e2e": "bun run e2e"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,16 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const isCI = !!process.env.CI;
+const e2eMode = process.env.E2E_MODE === "dev" ? "dev" : "preview";
 const defaultHost = process.env.PLAYWRIGHT_BASE_HOST ?? "127.0.0.1";
-const serverHost =
-  process.env.PLAYWRIGHT_HOST ?? (isCI ? "0.0.0.0" : defaultHost);
-const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
-const baseURL =
-  process.env.PLAYWRIGHT_BASE_URL ?? `http://${defaultHost}:${port}`;
+const serverHost = process.env.PLAYWRIGHT_HOST ?? (isCI ? "0.0.0.0" : defaultHost);
+const port = Number(process.env.PLAYWRIGHT_PORT ?? (e2eMode === "dev" ? 5173 : 4173));
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://${defaultHost}:${port}`;
+const webServerCommand =
+  e2eMode === "dev"
+    ? `bun run dev -- --host ${serverHost} --port ${port} --strictPort`
+    : `bun run build && bun x vite preview --host ${serverHost} --port ${port} --strictPort`;
 
 export default defineConfig({
-  testDir: "e2e",
-  testMatch: "**/*.e2e.ts",
+  testDir: "tests/e2e",
+  testMatch: "**/*.spec.ts",
   fullyParallel: false,
   retries: isCI ? 1 : 0,
   reporter: isCI ? [["github"], ["line"]] : "list",
@@ -25,7 +28,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `bun x --bun vite preview --host ${serverHost} --port ${port} --strictPort`,
+    command: webServerCommand,
     url: baseURL,
     reuseExistingServer: !isCI,
     timeout: 120000,

--- a/serve.ts
+++ b/serve.ts
@@ -5,9 +5,7 @@ const root = Deno.env.get("STATIC_DIR") ?? "dist";
 
 Deno.serve(async (req) => {
   const isHead = req.method === "HEAD";
-  const request = isHead
-    ? new Request(req.url, { method: "GET", headers: req.headers })
-    : req;
+  const request = isHead ? new Request(req.url, { method: "GET", headers: req.headers }) : req;
   const url = new URL(req.url);
   const path = url.pathname;
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+test("loads-homepage", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveTitle(/Stake|Ubiquity/i);
+  await expect(page.getByRole("heading", { name: /Ubiquity Staking/i })).toBeVisible();
+  await expect(page.locator("#root")).toBeVisible();
+});
+
+test("connect-wallet-visible", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("button", { name: /Connect Wallet/i })).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
-    "lib": [
-      "ES2023"
-    ],
+    "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,
     /* Bundler mode */
@@ -21,8 +19,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": [
-    "vite.config.ts",
-    "playwright.config.ts"
-  ]
+  "include": ["vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
Fixes #4

## Summary
- Adds a focused Playwright Chromium smoke suite for the staking app.
- Supports preview mode by default and dev-server mode via `E2E_MODE=dev`.
- Adds the requested `e2e`, `e2e:ui`, and `preview` scripts.
- Narrows `bun run test` to Bun unit tests so Playwright specs are not loaded by the Bun test runner.
- Documents the e2e commands in the README.

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bun run e2e`

Notes: `bun run e2e` builds successfully and runs both smoke tests against Vite preview. Existing font/chunk warnings are emitted by the production build but do not fail the run.