### PR TITLE
Add Bun unit coverage for staking UI

### DIFF
--- a/src/components/__tests__/button.test.tsx
+++ b/src/components/__tests__/button.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Button } from "../button";
+
+describe("Button", () => {
+  it("passes through props and children when idle", () => {
+    const markup = renderToStaticMarkup(<Button className="action-button">Stake</Button>);
+
+    expect(markup).toContain('class="action-button"');
+    expect(markup).toContain(">Stake</button>");
+    expect(markup).not.toContain("disabled");
+  });
+
+  it("disables the button and shows loading affordances while busy", () => {
+    const markup = renderToStaticMarkup(
+      <Button isLoading isLoadingText="Staking...">
+        Stake
+      </Button>
+    );
+
+    expect(markup).toContain("disabled");
+    expect(markup).toContain("spinner button-spinner");
+    expect(markup).toContain("Staking...");
+    expect(markup).not.toContain(">Stake</button>");
+  });
+});

--- a/src/components/__tests__/pool-display.test.ts
+++ b/src/components/__tests__/pool-display.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+
+import { getPoolDisplayMetrics } from "../pool-display";
+
+describe("PoolDisplay metrics", () => {
+  it("maps pool totals and user stake into displayable reward values", () => {
+    const metrics = getPoolDisplayMetrics({
+      rewardPerBlock: 10n * 10n ** 18n,
+      poolAllocationPoints: 25n,
+      totalAllocationPoints: 100n,
+      rewardTokenDecimals: 18,
+      poolAmount: 1_000n * 10n ** 18n,
+      userAmount: 100n * 10n ** 18n,
+      lpTokenDecimals: 18,
+    });
+
+    expect(metrics.poolRewardPerDay).toBe(17_917.5);
+    expect(metrics.userPoolShare).toBe(0.1);
+    expect(metrics.userRewardPerDay).toBe(1_791.75);
+  });
+
+  it("does not derive a user reward when the pool has no stake", () => {
+    const metrics = getPoolDisplayMetrics({
+      rewardPerBlock: 10n * 10n ** 18n,
+      poolAllocationPoints: 25n,
+      totalAllocationPoints: 100n,
+      rewardTokenDecimals: 18,
+      poolAmount: 0n,
+      userAmount: 100n * 10n ** 18n,
+      lpTokenDecimals: 18,
+    });
+
+    expect(metrics.userPoolShare).toBeNull();
+    expect(metrics.userRewardPerDay).toBeNull();
+  });
+});

--- a/src/components/pool-display.tsx
+++ b/src/components/pool-display.tsx
@@ -40,6 +40,34 @@ const WRITE_ACTION = {
 
 type WriteAction = (typeof WRITE_ACTION)[keyof typeof WRITE_ACTION];
 
+export function getPoolDisplayMetrics({
+  rewardPerBlock,
+  poolAllocationPoints,
+  totalAllocationPoints,
+  rewardTokenDecimals,
+  poolAmount,
+  userAmount,
+  lpTokenDecimals,
+}: {
+  rewardPerBlock: bigint;
+  poolAllocationPoints: bigint;
+  totalAllocationPoints: bigint;
+  rewardTokenDecimals: number;
+  poolAmount: bigint;
+  userAmount?: bigint;
+  lpTokenDecimals: number;
+}) {
+  const poolRewardPerDay = calculatePoolRewardPerDay(rewardPerBlock, poolAllocationPoints, totalAllocationPoints, rewardTokenDecimals);
+  const userPoolShare = userAmount !== undefined && poolAmount > 0n ? calculateUserPoolShare(userAmount, poolAmount, lpTokenDecimals) : null;
+  const userRewardPerDay = calculateUserRewardPerDay(userPoolShare, poolRewardPerDay);
+
+  return {
+    poolRewardPerDay,
+    userPoolShare,
+    userRewardPerDay,
+  };
+}
+
 export function PoolDisplay({ poolId = 0n }: PoolDisplayProps) {
   const { address, isConnected } = useAccount();
   const [stakeAmount, setStakeAmount] = useState("");
@@ -144,9 +172,15 @@ export function PoolDisplay({ poolId = 0n }: PoolDisplayProps) {
 
   const isAllowanceSufficient = staking.data.allowance.data !== undefined && parsedStakeAmount ? staking.data.allowance.data >= parsedStakeAmount : false;
 
-  const poolRewardPerDay = calculatePoolRewardPerDay(settings[3], pool.allocationPoints, settings[6], rewardToken.decimals);
-  const userPoolShare = userInfo && pool.amount > 0n ? calculateUserPoolShare(userInfo.amount, pool.amount, lpToken.decimals) : null;
-  const userRewardPerDay = calculateUserRewardPerDay(userPoolShare, poolRewardPerDay);
+  const { userPoolShare, userRewardPerDay } = getPoolDisplayMetrics({
+    rewardPerBlock: settings[3],
+    poolAllocationPoints: pool.allocationPoints,
+    totalAllocationPoints: settings[6],
+    rewardTokenDecimals: rewardToken.decimals,
+    poolAmount: pool.amount,
+    userAmount: userInfo?.amount,
+    lpTokenDecimals: lpToken.decimals,
+  });
   const isWritingContract = currentWriteAction !== WRITE_ACTION.NONE;
 
   return (

--- a/src/constants/__tests__/config.test.ts
+++ b/src/constants/__tests__/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+
+import { isDenoDeployHost, resolveRpcUrl } from "../config";
+
+describe("RPC config resolution", () => {
+  it("prefers an explicit RPC URL from the environment", () => {
+    expect(
+      resolveRpcUrl({
+        envRpcUrl: "https://rpc.example.com",
+        hostname: "stake.ubq.fi",
+        origin: "https://stake.ubq.fi",
+      })
+    ).toBe("https://rpc.example.com");
+  });
+
+  it("uses the shared RPC for Deno Deploy preview hosts", () => {
+    expect(isDenoDeployHost("stake-ubq-fi.deno.dev")).toBe(true);
+    expect(
+      resolveRpcUrl({
+        hostname: "preview-stake-ubq-fi.ubiquity-dao.deno.net",
+        origin: "https://preview-stake-ubq-fi.ubiquity-dao.deno.net",
+      })
+    ).toBe("https://rpc.ubq.fi");
+  });
+
+  it("falls back to the app origin RPC path for production hosts", () => {
+    expect(isDenoDeployHost("stake.ubq.fi")).toBe(false);
+    expect(
+      resolveRpcUrl({
+        hostname: "stake.ubq.fi",
+        origin: "https://stake.ubq.fi",
+      })
+    ).toBe("https://stake.ubq.fi/rpc");
+  });
+});

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -5,6 +5,26 @@
  */
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
+
+export function resolveRpcUrl({
+  envRpcUrl,
+  hostname,
+  origin,
+}: {
+  envRpcUrl?: string;
+  hostname?: string;
+  origin?: string;
+}) {
+  if (envRpcUrl) {
+    return envRpcUrl;
+  }
+
+  return isDenoDeployHost(hostname ?? "") ? "https://rpc.ubq.fi" : `${origin ?? ""}/rpc`;
+}
+
 const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+export const RPC_URL = resolveRpcUrl({
+  envRpcUrl: import.meta.env.VITE_RPC_URL,
+  hostname: currentLocation?.hostname,
+  origin: currentLocation?.origin,
+});


### PR DESCRIPTION
## Summary
- add focused Bun tests for RPC config resolution, button loading/disabled rendering, and pool-display reward/share mapping
- extract pure helpers for RPC URL resolution and PoolDisplay metrics so the behavior is easy to test without wallet/RPC setup
- keep production behavior unchanged while adding a minimal deterministic unit-test baseline

Resolves #3.

## Verification
- `npx --yes bun@latest test` (10 pass)
- `npx --yes bun@latest run lint`
- `npx --yes bun@latest run build` (passes; existing Vite font-resolution and large-chunk warnings remain)

## Notes
This targets the Devpool handoff for `Unit Tests (Bun Test)` and intentionally avoids adding heavy test dependencies.