### PR TITLE
feat(rpc): add health checks, validation, and runtime fallback(#5969 , #9)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
 import { DashboardPage } from "./components/dashboard-page";
+import { RpcHealthNotice } from "./components/rpc-health-notice";
 
 function App() {
-  return <DashboardPage />;
+  return (
+    <>
+      <RpcHealthNotice />
+      <DashboardPage />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/dashboard-page.tsx
+++ b/src/components/dashboard-page.tsx
@@ -4,6 +4,7 @@ import { PoolDisplay } from "./pool-display.tsx";
 import { ConnectWalletButton } from "./connect-wallet.tsx";
 import { supportedChains } from "../wallet/config.ts";
 import { useStatusMessageState } from "../context/status-message.tsx";
+import { DevRpcPanel } from "./dev-rpc-panel.tsx";
 
 const LogoSpan = () => <span id="header-logo-wrapper">{ICONS.DAO_LOGO}</span>;
 
@@ -46,6 +47,7 @@ export function DashboardPage() {
           </div>
         </section>
       )}
+      <DevRpcPanel />
 
       {isUnsupportedChain ? (
         <div className="pool-container">

--- a/src/components/dev-rpc-panel.tsx
+++ b/src/components/dev-rpc-panel.tsx
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from "react";
+import { getRpcRuntimeState, subscribeRpcRuntime } from "../utils/rpc-runtime";
+
+export function DevRpcPanel() {
+  const state = useSyncExternalStore(subscribeRpcRuntime, getRpcRuntimeState, getRpcRuntimeState);
+  const isProd = import.meta.env.MODE === "prod";
+
+  if (isProd) return null;
+
+  return (
+    <section style={{ margin: "12px 0", padding: "8px 12px", border: "1px solid #2f2f2f", fontSize: "12px", fontFamily: "monospace" }}>
+      <div>RPC: {state.resolvedRpcUrl}</div>
+      <div>Status: {state.lastStatus}</div>
+      <div>ChainId: {state.lastChainId ?? "n/a"}</div>
+      <div>Recent errors: {state.recentErrorCount}</div>
+    </section>
+  );
+}

--- a/src/components/rpc-health-notice.tsx
+++ b/src/components/rpc-health-notice.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { isLocalNode } from "../constants/config";
+import { useStatusMessageDispatch } from "../context/status-message";
+import { rpcHealthCheck } from "../utils/rpc-health";
+import { getResolvedRpcBaseUrl } from "../utils/rpc-runtime";
+
+export function RpcHealthNotice() {
+  const dispatch = useStatusMessageDispatch();
+
+  useEffect(() => {
+    if (!isLocalNode) return;
+
+    let cancelled = false;
+    const healthUrl = getResolvedRpcBaseUrl();
+
+    const check = async () => {
+      const result = await rpcHealthCheck(healthUrl, { timeoutMs: 1_500 });
+      if (cancelled) return;
+      if (result.status !== "healthy") {
+        dispatch({
+          type: "setError",
+          message: "Local node RPC unavailable at http://localhost:8545. Start Anvil and refresh.",
+        });
+      }
+    };
+
+    void check();
+    const id = setInterval(() => void check(), 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [dispatch]);
+
+  return null;
+}

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,10 +1,61 @@
-/**
- * RPC endpoint for blockchain calls.
- * - In development (including Deno Deploy preview links), it uses https://rpc.ubq.fi
- * - In production, it uses /rpc for performance.
- */
+export const DEFAULT_MAINNET_RPC_FALLBACKS = ["https://rpc.ubq.fi"] as const;
+const DEFAULT_LOCAL_RPC_URL = "http://localhost:8545";
+
+type AppMode = "dev" | "prod" | "local-node" | string;
+
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
+
+const hasHttpProtocol = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const isValidRpcUrl = (value: string): boolean => {
+  if (!value) return false;
+  if (value.startsWith("/")) return true;
+  return hasHttpProtocol(value);
+};
+
+export const getDefaultRpcUrl = (mode: AppMode, origin: string, hostname: string): string => {
+  if (mode === "local-node") return DEFAULT_LOCAL_RPC_URL;
+  if (mode === "dev" || isDenoDeployHost(hostname)) return DEFAULT_MAINNET_RPC_FALLBACKS[0];
+  return `${origin}/rpc`;
+};
+
+export const resolveRpcConfig = (params: {
+  mode: AppMode;
+  hostname: string;
+  origin: string;
+  envRpcUrl?: string;
+}): { rpcUrl: string; fallbackRpcUrls: string[] } => {
+  const { mode, hostname, origin, envRpcUrl } = params;
+  const defaultRpcUrl = getDefaultRpcUrl(mode, origin, hostname);
+  const fallbackRpcUrls = mode === "local-node" ? [DEFAULT_LOCAL_RPC_URL] : [...DEFAULT_MAINNET_RPC_FALLBACKS];
+
+  if (!envRpcUrl) {
+    return { rpcUrl: defaultRpcUrl, fallbackRpcUrls };
+  }
+
+  if (!isValidRpcUrl(envRpcUrl)) {
+    console.warn(`[rpc-config] Invalid VITE_RPC_URL "${envRpcUrl}". Falling back to "${defaultRpcUrl}".`);
+    return { rpcUrl: defaultRpcUrl, fallbackRpcUrls };
+  }
+
+  return { rpcUrl: envRpcUrl, fallbackRpcUrls };
+};
+
 const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+const resolved = resolveRpcConfig({
+  mode: import.meta.env.MODE,
+  envRpcUrl: import.meta.env.VITE_RPC_URL,
+  hostname: currentLocation?.hostname ?? "",
+  origin: currentLocation?.origin ?? "",
+});
+
+export const RPC_URL = resolved.rpcUrl;
+export const RPC_FALLBACK_URLS = resolved.fallbackRpcUrls;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { WagmiProvider } from "wagmi";
 import App from "./App.tsx";
 import { grid } from "./the-grid";
 import { StatusMessageProvider } from "./context/status-message.tsx";
-import { wagmiConfig } from "./wallet/config";
+import { initializeRpcRuntime } from "./utils/rpc-runtime";
 
 const queryClient = new QueryClient();
 
@@ -20,17 +20,24 @@ if (!gridElement) {
   console.warn("Could not find grid element for background animation");
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <StatusMessageProvider>
-          <App />
-        </StatusMessageProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
-  </StrictMode>
-);
+async function bootstrap() {
+  await initializeRpcRuntime();
+  const { wagmiConfig } = await import("./wallet/config");
+
+  createRoot(rootElement).render(
+    <StrictMode>
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <StatusMessageProvider>
+            <App />
+          </StatusMessageProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </StrictMode>
+  );
+}
+
+void bootstrap();
 
 if (gridElement) {
   grid(gridElement, () => document.body.classList.add("grid-loaded"));

--- a/src/utils/rpc-health.ts
+++ b/src/utils/rpc-health.ts
@@ -1,0 +1,72 @@
+export type RpcHealthStatus = "healthy" | "unhealthy" | "timeout";
+
+export type RpcHealthCheckResult = {
+  status: RpcHealthStatus;
+  rpcUrl: string;
+  chainIdHex?: string;
+  chainId?: number;
+  error?: string;
+};
+
+type RpcHealthCheckOptions = {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+const parseChainId = (value: string): number | undefined => {
+  const parsed = Number.parseInt(value, 16);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export async function rpcHealthCheck(rpcUrl: string, options: RpcHealthCheckOptions = {}): Promise<RpcHealthCheckResult> {
+  const { timeoutMs = 1_500, signal } = options;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const onAbort = () => controller.abort();
+  signal?.addEventListener("abort", onAbort);
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return { status: "unhealthy", rpcUrl, error: `HTTP ${response.status}` };
+    }
+
+    const payload = (await response.json()) as { result?: string; error?: { message?: string } };
+    if (typeof payload.result === "string") {
+      return {
+        status: "healthy",
+        rpcUrl,
+        chainIdHex: payload.result,
+        chainId: parseChainId(payload.result),
+      };
+    }
+
+    return {
+      status: "unhealthy",
+      rpcUrl,
+      error: payload.error?.message ?? "Unexpected RPC response",
+    };
+  } catch (error) {
+    const isTimeout = error instanceof DOMException && error.name === "AbortError";
+    return {
+      status: isTimeout ? "timeout" : "unhealthy",
+      rpcUrl,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
+  }
+}

--- a/src/utils/rpc-runtime.ts
+++ b/src/utils/rpc-runtime.ts
@@ -1,0 +1,69 @@
+import { isLocalNode, RPC_FALLBACK_URLS, RPC_URL } from "../constants/config";
+import { rpcHealthCheck, type RpcHealthCheckResult } from "./rpc-health";
+
+type RpcRuntimeState = {
+  resolvedRpcUrl: string;
+  lastChainId?: number;
+  lastStatus: RpcHealthCheckResult["status"] | "unknown";
+  recentErrorCount: number;
+  initialized: boolean;
+};
+
+const listeners = new Set<() => void>();
+const state: RpcRuntimeState = {
+  resolvedRpcUrl: RPC_URL,
+  lastStatus: "unknown",
+  recentErrorCount: 0,
+  initialized: false,
+};
+
+const MAINNET_CHAIN_ID = 1;
+
+const withChainPath = (baseUrl: string): string => (isLocalNode ? baseUrl : `${baseUrl}/${MAINNET_CHAIN_ID}`);
+
+const notify = () => {
+  listeners.forEach((listener) => listener());
+};
+
+export const subscribeRpcRuntime = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const getRpcRuntimeState = (): RpcRuntimeState => ({ ...state });
+export const getResolvedRpcBaseUrl = (): string => state.resolvedRpcUrl;
+
+export const __resetRpcRuntimeForTests = () => {
+  state.resolvedRpcUrl = RPC_URL;
+  state.lastChainId = undefined;
+  state.lastStatus = "unknown";
+  state.recentErrorCount = 0;
+  state.initialized = false;
+};
+
+export async function initializeRpcRuntime(): Promise<RpcRuntimeState> {
+  const candidates = [RPC_URL, ...RPC_FALLBACK_URLS].filter((url, index, list) => list.indexOf(url) === index);
+
+  for (const baseUrl of candidates) {
+    const result = await rpcHealthCheck(withChainPath(baseUrl), { timeoutMs: 1_500 });
+    state.lastStatus = result.status;
+    state.lastChainId = result.chainId;
+
+    if (result.status === "healthy") {
+      if (baseUrl !== RPC_URL) {
+        console.warn(`[rpc-runtime] Primary RPC failed quick check. Falling back to "${baseUrl}".`);
+      }
+      state.resolvedRpcUrl = baseUrl;
+      state.initialized = true;
+      notify();
+      return getRpcRuntimeState();
+    }
+
+    state.recentErrorCount += 1;
+  }
+
+  state.initialized = true;
+  console.warn(`[rpc-runtime] All RPC candidates failed quick health check. Using primary "${RPC_URL}" and relying on transport fallback.`);
+  notify();
+  return getRpcRuntimeState();
+}

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -1,6 +1,7 @@
 import { mainnet, anvil, type Chain } from "viem/chains";
-import { isLocalNode, RPC_URL } from "../constants/config";
-import { createConfig, http, injected, type Transport } from "wagmi";
+import { isLocalNode, RPC_FALLBACK_URLS, RPC_URL } from "../constants/config";
+import { createConfig, fallback, http, injected, type Transport } from "wagmi";
+import { getResolvedRpcBaseUrl } from "../utils/rpc-runtime";
 
 export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [mainnet, anvil] : [mainnet];
 
@@ -10,12 +11,18 @@ type TransportsMap = Record<ChainId, Transport>;
 // Anvil doesn't support URLs like http://localhost:8545/31337
 const transports = supportedChains.reduce<TransportsMap>((acc, chain) => {
   // In local-node mode, use raw RPC_URL without chain ID suffix for ALL chains
-  // In production/dev mode, append chain ID
-  const rpcUrl = isLocalNode ? RPC_URL : `${RPC_URL}/${chain.id}`;
+  // In production/dev mode, append chain ID and use fallback RPCs on failures
+  const activeBaseUrl = getResolvedRpcBaseUrl() || RPC_URL;
+  const rpcUrl = isLocalNode ? activeBaseUrl : `${activeBaseUrl}/${chain.id}`;
 
-  acc[chain.id] = http(rpcUrl, {
-    batch: isLocalNode ? false : true,
-  });
+  if (isLocalNode) {
+    acc[chain.id] = http(rpcUrl, { batch: false });
+    return acc;
+  }
+
+  const fallbackUrls = [rpcUrl, ...RPC_FALLBACK_URLS.map((url) => `${url}/${chain.id}`)].filter((url, index, list) => list.indexOf(url) === index);
+  const fallbackTransports = fallbackUrls.map((url) => http(url, { batch: true }));
+  acc[chain.id] = fallback(fallbackTransports);
   return acc;
 }, {} as TransportsMap);
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
-import { isDenoDeployHost } from "../src/constants/config";
+import { getDefaultRpcUrl, isDenoDeployHost, isValidRpcUrl, resolveRpcConfig } from "../src/constants/config";
+
+const warnSpy = mock(() => {});
+
+afterEach(() => {
+  warnSpy.mockReset();
+});
 
 describe("isDenoDeployHost", () => {
   it("matches Deno Deploy preview hostnames", () => {
@@ -11,5 +17,62 @@ describe("isDenoDeployHost", () => {
   it("does not match unrelated hostnames", () => {
     expect(isDenoDeployHost("stake.ubq.fi")).toBe(false);
     expect(isDenoDeployHost("localhost")).toBe(false);
+  });
+});
+
+describe("isValidRpcUrl", () => {
+  it("accepts https and relative rpc URLs", () => {
+    expect(isValidRpcUrl("https://rpc.ubq.fi")).toBe(true);
+    expect(isValidRpcUrl("http://localhost:8545")).toBe(true);
+    expect(isValidRpcUrl("/rpc")).toBe(true);
+  });
+
+  it("rejects malformed values", () => {
+    expect(isValidRpcUrl("ftp://rpc.ubq.fi")).toBe(false);
+    expect(isValidRpcUrl("not-a-url")).toBe(false);
+    expect(isValidRpcUrl("")).toBe(false);
+  });
+});
+
+describe("resolveRpcConfig", () => {
+  it("falls back in dev mode when VITE_RPC_URL is invalid", () => {
+    const originalWarn = console.warn;
+    console.warn = warnSpy;
+    try {
+      const result = resolveRpcConfig({
+        mode: "dev",
+        hostname: "localhost",
+        origin: "http://localhost:5173",
+        envRpcUrl: "this-is-invalid",
+      });
+
+      expect(result.rpcUrl).toBe("https://rpc.ubq.fi");
+      expect(result.fallbackRpcUrls).toContain("https://rpc.ubq.fi");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("uses localhost rpc in local-node mode", () => {
+    const result = resolveRpcConfig({
+      mode: "local-node",
+      hostname: "localhost",
+      origin: "http://localhost:5173",
+    });
+
+    expect(result.rpcUrl).toBe("http://localhost:8545");
+    expect(result.fallbackRpcUrls).toEqual(["http://localhost:8545"]);
+  });
+
+  it("uses /rpc in prod mode when env value is not set", () => {
+    const result = resolveRpcConfig({
+      mode: "prod",
+      hostname: "stake.ubq.fi",
+      origin: "https://stake.ubq.fi",
+    });
+
+    expect(getDefaultRpcUrl("prod", "https://stake.ubq.fi", "stake.ubq.fi")).toBe("https://stake.ubq.fi/rpc");
+    expect(result.rpcUrl).toBe("https://stake.ubq.fi/rpc");
   });
 });

--- a/tests/rpc-health.test.ts
+++ b/tests/rpc-health.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { rpcHealthCheck } from "../src/utils/rpc-health";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("rpcHealthCheck", () => {
+  it("returns healthy status with parsed chain id", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: "0x1",
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    const result = await rpcHealthCheck("https://rpc.ubq.fi");
+    expect(result.status).toBe("healthy");
+    expect(result.chainId).toBe(1);
+    expect(result.chainIdHex).toBe("0x1");
+  });
+
+  it("returns unhealthy status on rpc error payload", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { message: "bad upstream" },
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    const result = await rpcHealthCheck("https://rpc.ubq.fi");
+    expect(result.status).toBe("unhealthy");
+    expect(result.error).toContain("bad upstream");
+  });
+
+  it("returns timeout status when aborted by timeout", async () => {
+    globalThis.fetch = mock(
+      () =>
+        new Promise<Response>((_, reject) => {
+          setTimeout(() => reject(new DOMException("timeout", "AbortError")), 20);
+        }),
+    ) as typeof fetch;
+
+    const result = await rpcHealthCheck("http://localhost:8545", { timeoutMs: 1 });
+    expect(result.status).toBe("timeout");
+  });
+});

--- a/tests/rpc-runtime.test.ts
+++ b/tests/rpc-runtime.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { RPC_FALLBACK_URLS, RPC_URL } from "../src/constants/config";
+import { __resetRpcRuntimeForTests, getRpcRuntimeState, initializeRpcRuntime } from "../src/utils/rpc-runtime";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  __resetRpcRuntimeForTests();
+});
+
+describe("initializeRpcRuntime", () => {
+  it("keeps primary RPC when health check passes", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: "0x1",
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    await initializeRpcRuntime();
+    const state = getRpcRuntimeState();
+    expect(state.resolvedRpcUrl).toBe(RPC_URL);
+    expect(state.lastStatus).toBe("healthy");
+    expect(state.recentErrorCount).toBe(0);
+  });
+
+  it("falls back when primary fails quick check", async () => {
+    const fallback = RPC_FALLBACK_URLS[0];
+    const primaryProbeUrl = `${RPC_URL}/1`;
+    const fallbackProbeUrl = `${fallback}/1`;
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === primaryProbeUrl) {
+        return new Response(JSON.stringify({ error: { message: "primary down" } }), { status: 200 });
+      }
+      if (url === fallbackProbeUrl) {
+        return new Response(JSON.stringify({ result: "0x1" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: { message: "unexpected" } }), { status: 500 });
+    }) as typeof fetch;
+
+    await initializeRpcRuntime();
+    const state = getRpcRuntimeState();
+    expect(state.resolvedRpcUrl).toBe(fallback);
+    expect(state.recentErrorCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary #9 , https://github.com/devpool-directory/devpool-directory/issues/5969
This PR hardens RPC behavior to reduce flaky UX across dev, local-node, and prod modes.

## Changes
- Added strict `VITE_RPC_URL` validation with clear misconfiguration warnings.
- Added mode-aware RPC resolution defaults and fallback candidate handling.
- Added lightweight `rpcHealthCheck()` (`eth_chainId`, short timeout, typed status).
- Added startup RPC runtime initialization that probes primary then fallback(s).
- Kept local-node behavior unsuffixed (`http://localhost:8545`, no `/${chainId}`).
- Added dev-only RPC diagnostics panel (hidden in prod).
- Added local-node health notice for unavailable Anvil without app crash.
- Expanded unit tests for config, health utility, and runtime fallback branches.

## Validation
- `bun test` passes (13/13).

## Notes
- Backward compatibility preserved for existing config consumers (`RPC_URL` still exported).

closes #9 and #5969