### PR TITLE
Add Playwright smoke tests for the staking app

### DIFF
--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-test("renders landing page", async ({ page }) => {
+test("loads-homepage", async ({ page }) => {
   await page.goto("/");
-  await expect(page.locator("body")).toBeVisible();
+
+  await expect(page).toHaveTitle(/stake|ubiquity/i);
+  await expect(page.getByRole("heading", { name: /ubiquity\s+staking/i })).toBeVisible();
+});
+
+test("connect-wallet-visible", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("button", { name: /connect wallet/i })).toBeVisible();
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "bun test",
-    "test:e2e": "bun x playwright test"
+    "preview": "vite preview --port 4173",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
 
 const isCI = !!process.env.CI;
+const e2eMode = process.env.E2E_MODE ?? "preview";
+
+if (e2eMode !== "dev" && e2eMode !== "preview") {
+  throw new Error("E2E_MODE must be either 'dev' or 'preview'.");
+}
+
 const defaultHost = process.env.PLAYWRIGHT_BASE_HOST ?? "127.0.0.1";
-const serverHost =
-  process.env.PLAYWRIGHT_HOST ?? (isCI ? "0.0.0.0" : defaultHost);
-const port = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
-const baseURL =
-  process.env.PLAYWRIGHT_BASE_URL ?? `http://${defaultHost}:${port}`;
+const serverHost = process.env.PLAYWRIGHT_HOST ?? (isCI ? "0.0.0.0" : defaultHost);
+const port = Number(process.env.PLAYWRIGHT_PORT ?? (e2eMode === "dev" ? 5173 : 4173));
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://${defaultHost}:${port}`;
+const viteCommand = "node ./node_modules/vite/bin/vite.js";
+const previewCommand = `${viteCommand} build --mode prod && ${viteCommand} preview --host ${serverHost} --port ${port} --strictPort`;
+const devCommand = `${viteCommand} --mode dev --host ${serverHost} --port ${port} --strictPort`;
 
 export default defineConfig({
   testDir: "e2e",
@@ -25,12 +32,10 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `bun x --bun vite preview --host ${serverHost} --port ${port} --strictPort`,
+    command: e2eMode === "dev" ? devCommand : previewCommand,
     url: baseURL,
     reuseExistingServer: !isCI,
     timeout: 120000,
-    env: {
-      NODE_ENV: "production",
-    },
+    env: e2eMode === "preview" ? { NODE_ENV: "production" } : undefined,
   },
 });


### PR DESCRIPTION
﻿## Summary

- Added Playwright smoke coverage for the homepage and connect-wallet entry point.
- Added `e2e`, `e2e:ui`, and `preview` scripts.
- Updated Playwright config to auto-start either preview mode by default or dev mode via `E2E_MODE=dev`.

Closes #4

## Testing

- `playwright test` - passed, 2 tests
- `E2E_MODE=dev playwright test` - passed, 2 tests
- `vite build --mode prod` - passed
- `eslint .` - passed
- `prettier --check e2e/smoke.e2e.ts package.json playwright.config.ts` - passed

## Notes

- The normal `bun test` suite was not run successfully locally because Bun is not installed in this environment.
