### PR TITLE
feat: add RPC health checks and fallback transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,22 +95,25 @@ cast rpc evm_mine
 
 ## 🔧 Scripts
 
-| Script | Purpose |
-|--------|---------|
-| `bun run dev` | Dev server (MODE=dev) using remote RPC |
+| Script          | Purpose                                                      |
+| --------------- | ------------------------------------------------------------ |
+| `bun run dev`   | Dev server (MODE=dev) using remote RPC                       |
 | `bun run local` | Dev server (MODE=local-node) enabling `anvil` chain id 31337 |
-| `bun run build` | Production build to `dist/` |
-| `bun run lint` | ESLint over the repo |
+| `bun run build` | Production build to `dist/`                                  |
+| `bun run lint`  | ESLint over the repo                                         |
 
 ## 🌐 RPC Resolution
 
 Defined in `src/constants/config.ts`:
 
-1. If `VITE_RPC_URL` env var is set → use it directly.
-2. Else if development build or hostname includes `.deno.dev` (preview) → `https://rpc.ubq.fi`.
-3. Else in production build → relative `/rpc` (can be reverse‑proxied / cached).
+1. If `VITE_RPC_URL` env var is set and valid → use it directly.
+2. Invalid RPC URLs emit a console warning and fall back to the mode default.
+3. Else if development build or hostname includes `.deno.dev` (preview) → `https://rpc.ubq.fi`.
+4. Else in production build → relative `/rpc` (can be reverse‑proxied / cached).
 
-`local-node` mode adds the Anvil chain (31337) and uses the raw `RPC_URL` (no chain ID suffix) for all chains.
+Mainnet transports use viem's fallback transport so a custom or proxied primary RPC can fall back to `https://rpc.ubq.fi` when requests fail. `local-node` mode adds the Anvil chain (31337), skips fallback endpoints, and uses the raw `RPC_URL` (no chain ID suffix) for all chains.
+
+`src/utils/rpc-health.ts` exposes `rpcHealthCheck()` for diagnostics and tests. It probes `eth_chainId` with a short timeout and reports typed success, error, status, latency, and timeout details.
 
 ## 📦 Production Build & Deploy
 

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,10 +1,73 @@
 /**
  * RPC endpoint for blockchain calls.
- * - In development (including Deno Deploy preview links), it uses https://rpc.ubq.fi
+ * - In local-node mode, it uses a raw local Anvil URL with no chain suffix.
+ * - In development (including Deno Deploy preview links), it uses https://rpc.ubq.fi.
  * - In production, it uses /rpc for performance.
  */
+export const MAINNET_RPC_FALLBACK_URL = "https://rpc.ubq.fi";
+export const LOCAL_NODE_RPC_URL = "http://localhost:8545";
+export const PRODUCTION_RPC_PATH = "/rpc";
+
+type LocationLike = Pick<Location, "hostname" | "origin">;
+type WarningLogger = (message: string) => void;
+
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
+
+export function isValidRpcUrl(rpcUrl: string): boolean {
+  try {
+    const parsed = new URL(rpcUrl);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return rpcUrl.startsWith("/");
+  }
+}
+
+export function normalizeRpcUrl(rpcUrl: string): string {
+  if (rpcUrl === "/") return rpcUrl;
+  return rpcUrl.replace(/\/+$/, "");
+}
+
+export function getDefaultRpcUrl(mode: string, location?: LocationLike): string {
+  if (mode === "local-node") return LOCAL_NODE_RPC_URL;
+  if (mode === "dev" || isDenoDeployHost(location?.hostname ?? "")) return MAINNET_RPC_FALLBACK_URL;
+  return location?.origin ? `${location.origin}${PRODUCTION_RPC_PATH}` : PRODUCTION_RPC_PATH;
+}
+
+export function resolveRpcUrl({
+  envRpcUrl,
+  location,
+  mode,
+  warn = console.warn,
+}: {
+  envRpcUrl?: string;
+  location?: LocationLike;
+  mode: string;
+  warn?: WarningLogger;
+}): string {
+  if (envRpcUrl) {
+    if (isValidRpcUrl(envRpcUrl)) return normalizeRpcUrl(envRpcUrl);
+    const fallbackUrl = getDefaultRpcUrl(mode, location);
+    warn(`Invalid VITE_RPC_URL "${envRpcUrl}". Falling back to ${fallbackUrl}.`);
+    return fallbackUrl;
+  }
+
+  return getDefaultRpcUrl(mode, location);
+}
+
+export function getRpcFallbackUrls(primaryRpcUrl: string, mode: string): string[] {
+  if (mode === "local-node") return [];
+  const normalizedPrimary = normalizeRpcUrl(primaryRpcUrl);
+  return normalizedPrimary === MAINNET_RPC_FALLBACK_URL ? [] : [MAINNET_RPC_FALLBACK_URL];
+}
+
 const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+const currentMode = import.meta.env.MODE ?? "prod";
+
+export const RPC_URL = resolveRpcUrl({
+  envRpcUrl: import.meta.env.VITE_RPC_URL,
+  location: currentLocation,
+  mode: currentMode,
+});
+
+export const RPC_FALLBACK_URLS = getRpcFallbackUrls(RPC_URL, currentMode);

--- a/src/utils/rpc-health.ts
+++ b/src/utils/rpc-health.ts
@@ -1,0 +1,81 @@
+export type RpcHealthStatus =
+  | {
+      ok: true;
+      url: string;
+      chainId: number;
+      latencyMs: number;
+    }
+  | {
+      ok: false;
+      url: string;
+      error: string;
+      latencyMs: number;
+      status?: number;
+      timedOut?: boolean;
+    };
+
+type RpcFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function parseChainId(chainId: unknown): number | null {
+  if (typeof chainId !== "string") return null;
+  const parsed = Number.parseInt(chainId, chainId.startsWith("0x") ? 16 : 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function rpcHealthCheck(
+  url: string,
+  {
+    fetchFn = fetch,
+    timeoutMs = 1500,
+  }: {
+    fetchFn?: RpcFetch;
+    timeoutMs?: number;
+  } = {}
+): Promise<RpcHealthStatus> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchFn(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+      }),
+      signal: controller.signal,
+    });
+
+    const latencyMs = Date.now() - startedAt;
+    if (!response.ok) {
+      return { ok: false, url, status: response.status, error: `HTTP ${response.status}`, latencyMs };
+    }
+
+    const data = (await response.json()) as { result?: unknown; error?: { message?: string } };
+    if (data.error) {
+      return { ok: false, url, error: data.error.message ?? "RPC error", latencyMs };
+    }
+
+    const chainId = parseChainId(data.result);
+    if (chainId === null) {
+      return { ok: false, url, error: "Invalid eth_chainId response", latencyMs };
+    }
+
+    return { ok: true, url, chainId, latencyMs };
+  } catch (error) {
+    const latencyMs = Date.now() - startedAt;
+    const timedOut = error instanceof DOMException && error.name === "AbortError";
+    return { ok: false, url, error: timedOut ? `Timed out after ${timeoutMs}ms` : errorMessage(error), latencyMs, timedOut };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly MODE: string;
   readonly VITE_RPC_URL?: string;
 }
 

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -1,5 +1,6 @@
 import { mainnet, anvil, type Chain } from "viem/chains";
-import { isLocalNode, RPC_URL } from "../constants/config";
+import { fallback } from "viem";
+import { isLocalNode, RPC_FALLBACK_URLS, RPC_URL } from "../constants/config";
 import { createConfig, http, injected, type Transport } from "wagmi";
 
 export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [mainnet, anvil] : [mainnet];
@@ -7,15 +8,44 @@ export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [main
 type ChainId = (typeof supportedChains)[number]["id"];
 type TransportsMap = Record<ChainId, Transport>;
 
+export function getChainRpcUrl(rpcUrl: string, chainId: number, localNode = isLocalNode): string {
+  if (localNode) return rpcUrl;
+  return `${rpcUrl}/${chainId}`;
+}
+
+export function getRpcTransportUrls(
+  chain: Chain,
+  {
+    fallbackUrls = RPC_FALLBACK_URLS,
+    localNode = isLocalNode,
+    rpcUrl = RPC_URL,
+  }: {
+    fallbackUrls?: string[];
+    localNode?: boolean;
+    rpcUrl?: string;
+  } = {}
+): string[] {
+  const rpcUrls = localNode ? [rpcUrl] : [rpcUrl, ...fallbackUrls];
+  return rpcUrls.map((currentRpcUrl) => getChainRpcUrl(currentRpcUrl, chain.id, localNode));
+}
+
+function createRpcTransport(chain: Chain): Transport {
+  const rpcUrls = getRpcTransportUrls(chain);
+  const transports = rpcUrls.map((rpcUrl) =>
+    http(rpcUrl, {
+      batch: isLocalNode ? false : true,
+    })
+  );
+
+  if (transports.length === 1) return transports[0];
+  return fallback(transports, {
+    rank: false,
+  });
+}
+
 // Anvil doesn't support URLs like http://localhost:8545/31337
 const transports = supportedChains.reduce<TransportsMap>((acc, chain) => {
-  // In local-node mode, use raw RPC_URL without chain ID suffix for ALL chains
-  // In production/dev mode, append chain ID
-  const rpcUrl = isLocalNode ? RPC_URL : `${RPC_URL}/${chain.id}`;
-
-  acc[chain.id] = http(rpcUrl, {
-    batch: isLocalNode ? false : true,
-  });
+  acc[chain.id] = createRpcTransport(chain);
   return acc;
 }, {} as TransportsMap);
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { isDenoDeployHost } from "../src/constants/config";
+import { getDefaultRpcUrl, getRpcFallbackUrls, isDenoDeployHost, isValidRpcUrl, resolveRpcUrl } from "../src/constants/config";
 
 describe("isDenoDeployHost", () => {
   it("matches Deno Deploy preview hostnames", () => {
@@ -11,5 +11,43 @@ describe("isDenoDeployHost", () => {
   it("does not match unrelated hostnames", () => {
     expect(isDenoDeployHost("stake.ubq.fi")).toBe(false);
     expect(isDenoDeployHost("localhost")).toBe(false);
+  });
+});
+
+describe("RPC config resolution", () => {
+  it("validates HTTP(S) and relative RPC URLs", () => {
+    expect(isValidRpcUrl("https://rpc.ubq.fi")).toBe(true);
+    expect(isValidRpcUrl("http://localhost:8545")).toBe(true);
+    expect(isValidRpcUrl("/rpc")).toBe(true);
+    expect(isValidRpcUrl("not a url")).toBe(false);
+  });
+
+  it("falls back to public RPC when dev VITE_RPC_URL is invalid", () => {
+    const warnings: string[] = [];
+    const resolved = resolveRpcUrl({
+      envRpcUrl: "bad url",
+      location: { hostname: "localhost", origin: "http://localhost:5173" },
+      mode: "dev",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(resolved).toBe("https://rpc.ubq.fi");
+    expect(warnings[0]).toContain("Invalid VITE_RPC_URL");
+  });
+
+  it("keeps local-node mode on raw Anvil URL", () => {
+    expect(getDefaultRpcUrl("local-node")).toBe("http://localhost:8545");
+    expect(
+      resolveRpcUrl({
+        envRpcUrl: "http://localhost:8545",
+        mode: "local-node",
+      })
+    ).toBe("http://localhost:8545");
+  });
+
+  it("adds mainnet fallback when primary RPC differs", () => {
+    expect(getRpcFallbackUrls("https://custom-rpc.example", "dev")).toEqual(["https://rpc.ubq.fi"]);
+    expect(getRpcFallbackUrls("https://rpc.ubq.fi", "dev")).toEqual([]);
+    expect(getRpcFallbackUrls("http://localhost:8545", "local-node")).toEqual([]);
   });
 });

--- a/tests/rpc-health.test.ts
+++ b/tests/rpc-health.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import { rpcHealthCheck } from "../src/utils/rpc-health";
+
+describe("rpcHealthCheck", () => {
+  it("returns chain id for healthy RPC response", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      fetchFn: async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
+          status: 200,
+        }),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.chainId).toBe(1);
+  });
+
+  it("reports non-ok HTTP responses", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      fetchFn: async () => new Response("nope", { status: 502 }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toBe("HTTP 502");
+    }
+  });
+
+  it("reports RPC error payloads", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      fetchFn: async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, error: { message: "upstream failed" } }), {
+          status: 200,
+        }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("upstream failed");
+  });
+
+  it("times out hanging RPC calls", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      timeoutMs: 1,
+      fetchFn: (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+        }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.timedOut).toBe(true);
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "ES2022",
     "moduleResolution": "bundler",
     "strict": true,
+    "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "../src/vite-env.d.ts"]
 }

--- a/tests/wallet-config.test.ts
+++ b/tests/wallet-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+
+import { getChainRpcUrl, getRpcTransportUrls } from "../src/wallet/config";
+
+describe("wallet RPC transport config", () => {
+  it("appends chain id to mainnet RPC endpoints", () => {
+    expect(getChainRpcUrl("https://rpc.ubq.fi", 1)).toBe("https://rpc.ubq.fi/1");
+  });
+
+  it("keeps local-node RPC endpoints unsuffixed", () => {
+    expect(getChainRpcUrl("http://localhost:8545", 31337, true)).toBe("http://localhost:8545");
+  });
+
+  it("exposes RPC URLs that are wired into wagmi transports", () => {
+    expect(getRpcTransportUrls({ id: 1 } as Parameters<typeof getRpcTransportUrls>[0])).toContain("https://rpc.ubq.fi/1");
+  });
+
+  it("skips fallback endpoints for local-node transports", () => {
+    expect(
+      getRpcTransportUrls({ id: 31337 } as Parameters<typeof getRpcTransportUrls>[0], {
+        fallbackUrls: ["https://rpc.ubq.fi"],
+        localNode: true,
+        rpcUrl: "http://localhost:8545",
+      })
+    ).toEqual(["http://localhost:8545"]);
+  });
+});


### PR DESCRIPTION
Resolves #9

## Summary
- validate `VITE_RPC_URL` and fall back to mode defaults with clear warnings
- add typed `rpcHealthCheck()` using `eth_chainId` with timeout and error details
- wire viem fallback transport into wagmi RPC transports for mainnet
- preserve local-node raw Anvil RPC behavior with no chain suffix or fallback endpoints
- document RPC resolution and fallback behavior

## Validation
- `bun x prettier --check README.md src/constants/config.ts src/wallet/config.ts src/utils/rpc-health.ts src/vite-env.d.ts tests/config.test.ts tests/rpc-health.test.ts tests/wallet-config.test.ts tests/tsconfig.json`
- `git diff --check`
- `bun test`
- `bun run lint`
- `bun run build`
- `bun x tsc -b`
- `bun x tsc -p tests/tsconfig.json`