### PR TITLE
Add RPC config validation and health fallback

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -5,6 +5,116 @@
  */
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
-const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+
+const DEFAULT_PUBLIC_RPC_URL = "https://rpc.ubq.fi";
+const LOCAL_NODE_RPC_URL = "http://localhost:8545";
+
+export type RpcMode = "dev" | "local-node" | "prod";
+
+export interface RpcConfig {
+  mode: RpcMode;
+  url: string;
+  fallbacks: string[];
+  shouldAppendChainId: boolean;
+  warnings: string[];
+}
+
+function normalizeUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function isHttpUrl(value: string): boolean {
+  if (!/^https?:\/\//i.test(value)) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function warnOnce(message: string): void {
+  if (typeof console !== "undefined") {
+    console.warn(message);
+  }
+}
+
+function currentHostname(): string {
+  return typeof globalThis.location !== "undefined" ? globalThis.location.hostname : "";
+}
+
+function currentOrigin(): string {
+  return typeof globalThis.location !== "undefined" ? globalThis.location.origin : "";
+}
+
+export function resolveRpcConfig(
+  mode = import.meta.env.MODE,
+  envRpcUrl = import.meta.env.VITE_RPC_URL,
+  hostname = currentHostname(),
+  origin = currentOrigin()
+): RpcConfig {
+  const normalizedEnvRpc = normalizeUrl(envRpcUrl);
+  const warnings: string[] = [];
+  const rpcMode: RpcMode = mode === "local-node" ? "local-node" : mode === "prod" ? "prod" : "dev";
+
+  if (rpcMode === "local-node") {
+    const url = normalizedEnvRpc || LOCAL_NODE_RPC_URL;
+    if (!isHttpUrl(url)) {
+      warnings.push(`Invalid local-node VITE_RPC_URL "${url}". Falling back to ${LOCAL_NODE_RPC_URL}.`);
+      return {
+        mode: rpcMode,
+        url: LOCAL_NODE_RPC_URL,
+        fallbacks: [],
+        shouldAppendChainId: false,
+        warnings,
+      };
+    }
+    return {
+      mode: rpcMode,
+      url,
+      fallbacks: [],
+      shouldAppendChainId: false,
+      warnings,
+    };
+  }
+
+  if (normalizedEnvRpc) {
+    if (isHttpUrl(normalizedEnvRpc)) {
+      return {
+        mode: rpcMode,
+        url: normalizedEnvRpc,
+        fallbacks: normalizedEnvRpc === DEFAULT_PUBLIC_RPC_URL ? [] : [DEFAULT_PUBLIC_RPC_URL],
+        shouldAppendChainId: true,
+        warnings,
+      };
+    }
+    warnings.push(`Invalid VITE_RPC_URL "${normalizedEnvRpc}". Falling back to ${DEFAULT_PUBLIC_RPC_URL}.`);
+    return {
+      mode: rpcMode,
+      url: DEFAULT_PUBLIC_RPC_URL,
+      fallbacks: [],
+      shouldAppendChainId: true,
+      warnings,
+    };
+  }
+
+  const url = isDenoDeployHost(hostname) ? DEFAULT_PUBLIC_RPC_URL : `${origin}/rpc`;
+  return {
+    mode: rpcMode,
+    url,
+    fallbacks: url === DEFAULT_PUBLIC_RPC_URL ? [] : [DEFAULT_PUBLIC_RPC_URL],
+    shouldAppendChainId: true,
+    warnings,
+  };
+}
+
+export const RPC_CONFIG = resolveRpcConfig();
+
+for (const warning of RPC_CONFIG.warnings) {
+  warnOnce(warning);
+}
+
+export const RPC_URL = RPC_CONFIG.url;

--- a/src/utils/rpc-health.ts
+++ b/src/utils/rpc-health.ts
@@ -1,0 +1,64 @@
+import { RPC_CONFIG, type RpcConfig } from "../constants/config";
+
+export interface RpcHealthStatus {
+  ok: boolean;
+  url: string;
+  chainId?: string;
+  error?: string;
+}
+
+const ETH_CHAIN_ID_PAYLOAD = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "eth_chainId",
+  params: [],
+});
+
+function chainRpcUrl(baseUrl: string, chainId: number, shouldAppendChainId: boolean): string {
+  if (!shouldAppendChainId) {
+    return baseUrl;
+  }
+  return `${baseUrl.replace(/\/$/, "")}/${chainId}`;
+}
+
+export async function rpcHealthCheck(
+  chainId = 1,
+  config: RpcConfig = RPC_CONFIG,
+  timeoutMs = 1500
+): Promise<RpcHealthStatus> {
+  const candidates = [config.url, ...config.fallbacks];
+  let lastError = "RPC health check failed";
+
+  for (const baseUrl of candidates) {
+    const url = chainRpcUrl(baseUrl, chainId, config.shouldAppendChainId);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: ETH_CHAIN_ID_PAYLOAD,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        lastError = `HTTP ${response.status}`;
+        continue;
+      }
+      const json = (await response.json()) as { result?: string; error?: { message?: string } };
+      if (typeof json.result === "string") {
+        return { ok: true, url, chainId: json.result };
+      }
+      lastError = json.error?.message || "Missing eth_chainId result";
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return {
+    ok: false,
+    url: candidates[0],
+    error: lastError,
+  };
+}

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -1,5 +1,5 @@
 import { mainnet, anvil, type Chain } from "viem/chains";
-import { isLocalNode, RPC_URL } from "../constants/config";
+import { isLocalNode, RPC_CONFIG } from "../constants/config";
 import { createConfig, http, injected, type Transport } from "wagmi";
 
 export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [mainnet, anvil] : [mainnet];
@@ -9,9 +9,7 @@ type TransportsMap = Record<ChainId, Transport>;
 
 // Anvil doesn't support URLs like http://localhost:8545/31337
 const transports = supportedChains.reduce<TransportsMap>((acc, chain) => {
-  // In local-node mode, use raw RPC_URL without chain ID suffix for ALL chains
-  // In production/dev mode, append chain ID
-  const rpcUrl = isLocalNode ? RPC_URL : `${RPC_URL}/${chain.id}`;
+  const rpcUrl = RPC_CONFIG.shouldAppendChainId ? `${RPC_CONFIG.url.replace(/\/$/, "")}/${chain.id}` : RPC_CONFIG.url;
 
   acc[chain.id] = http(rpcUrl, {
     batch: isLocalNode ? false : true,

--- a/tests/rpc-config.test.ts
+++ b/tests/rpc-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { isDenoDeployHost, resolveRpcConfig } from "../src/constants/config";
+
+describe("resolveRpcConfig", () => {
+  it("keeps local-node RPC raw and disables chain suffixing", () => {
+    const config = resolveRpcConfig("local-node", undefined, "localhost", "http://localhost:5173");
+
+    expect(config.url).toBe("http://localhost:8545");
+    expect(config.fallbacks).toEqual([]);
+    expect(config.shouldAppendChainId).toBe(false);
+  });
+
+  it("uses valid VITE_RPC_URL with public fallback in dev mode", () => {
+    const config = resolveRpcConfig("dev", "https://rpc.example.com", "localhost", "http://localhost:5173");
+
+    expect(config.url).toBe("https://rpc.example.com");
+    expect(config.fallbacks).toEqual(["https://rpc.ubq.fi"]);
+    expect(config.shouldAppendChainId).toBe(true);
+    expect(config.warnings).toEqual([]);
+  });
+
+  it("falls back with a warning for invalid VITE_RPC_URL", () => {
+    const config = resolveRpcConfig("dev", "not a url", "localhost", "http://localhost:5173");
+
+    expect(config.url).toBe("https://rpc.ubq.fi");
+    expect(config.warnings[0]).toContain("Invalid VITE_RPC_URL");
+  });
+
+  it("uses relative production RPC outside Deno preview", () => {
+    const config = resolveRpcConfig("prod", undefined, "stake.ubq.fi", "https://stake.ubq.fi");
+
+    expect(config.url).toBe("https://stake.ubq.fi/rpc");
+    expect(config.fallbacks).toEqual(["https://rpc.ubq.fi"]);
+  });
+
+  it("uses public RPC for Deno deploy hosts", () => {
+    expect(isDenoDeployHost("preview.deno.dev")).toBe(true);
+    expect(isDenoDeployHost("preview.deno.net")).toBe(true);
+    expect(resolveRpcConfig("prod", undefined, "preview.deno.net", "https://preview.deno.net").url).toBe(
+      "https://rpc.ubq.fi"
+    );
+  });
+});

--- a/tests/rpc-health.test.ts
+++ b/tests/rpc-health.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { RpcConfig } from "../src/constants/config";
+import { rpcHealthCheck } from "../src/utils/rpc-health";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function config(overrides: Partial<RpcConfig> = {}): RpcConfig {
+  return {
+    mode: "dev",
+    url: "https://primary.example",
+    fallbacks: ["https://fallback.example"],
+    shouldAppendChainId: true,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("rpcHealthCheck", () => {
+  it("returns the first healthy candidate", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ result: "0x1" }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await rpcHealthCheck(1, config());
+
+    expect(result).toEqual({
+      ok: true,
+      url: "https://primary.example/1",
+      chainId: "0x1",
+    });
+    expect(calls).toEqual(["https://primary.example/1"]);
+  });
+
+  it("falls back after a failed primary RPC", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url));
+      if (calls.length === 1) {
+        return new Response("nope", { status: 500 });
+      }
+      return new Response(JSON.stringify({ result: "0x1" }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await rpcHealthCheck(1, config());
+
+    expect(result.ok).toBe(true);
+    expect(result.url).toBe("https://fallback.example/1");
+    expect(calls).toEqual(["https://primary.example/1", "https://fallback.example/1"]);
+  });
+
+  it("does not append chain id for local-node config", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ result: "0x1" }), { status: 200 });
+    }) as typeof fetch;
+
+    await rpcHealthCheck(
+      31337,
+      config({
+        mode: "local-node",
+        url: "http://localhost:8545",
+        fallbacks: [],
+        shouldAppendChainId: false,
+      })
+    );
+
+    expect(calls).toEqual(["http://localhost:8545"]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #9.

- Adds typed RPC configuration resolution with URL validation, explicit local-node handling, and fallback RPC candidates.
- Adds a lightweight `rpcHealthCheck()` helper that probes `eth_chainId` with timeout/fallback behavior.
- Keeps the existing exported `RPC_URL` and `isLocalNode` API compatible while letting wallet transports reuse the richer config.
- Adds Bun tests for dev/prod/local-node/Deno-preview config branches and RPC health fallback behavior.

## Validation

- `npx --yes bun@1.3.3 test`
- `npx --yes bun@1.3.3 run lint`
- `npx --yes bun@1.3.3 run build`

## Notes

This addresses #9 against the current public `development` branch. The issue body mentions `pr-1`, but `refs/heads/pr-1` was not publicly downloadable via GitHub codeload during preparation, while `development` contains the relevant wallet/RPC code path.
