### PR TITLE
fix: harden rpc configuration

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,10 +1,101 @@
 /**
- * RPC endpoint for blockchain calls.
- * - In development (including Deno Deploy preview links), it uses https://rpc.ubq.fi
- * - In production, it uses /rpc for performance.
+ * RPC endpoint resolution for blockchain calls.
+ * - local-node mode always talks to the raw Anvil URL without a chain suffix.
+ * - Development and Deno Deploy preview links default to https://rpc.ubq.fi.
+ * - Production defaults to the relative /rpc proxy and can fall back to public RPC.
  */
+export const DEFAULT_MAINNET_RPC_URL = "https://rpc.ubq.fi";
+export const LOCAL_NODE_RPC_URL = "http://localhost:8545";
+export const PRODUCTION_RPC_PATH = "/rpc";
+
+export type RpcResolution = {
+  rpcUrl: string;
+  fallbackRpcUrls: string[];
+  warnings: string[];
+};
+
+type RpcResolutionInput = {
+  envRpcUrl?: string;
+  hostname?: string;
+  mode: string;
+  origin?: string;
+  warn?: (message: string) => void;
+};
+
 export const isLocalNode = import.meta.env.MODE === "local-node";
 export const isDenoDeployHost = (hostname: string) => hostname.endsWith(".deno.dev") || hostname.endsWith(".deno.net");
+
+export function isValidRpcUrl(value: string, origin = "http://localhost"): boolean {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return false;
+  }
+
+  if (!trimmed.startsWith("/") && !/^https?:\/\//i.test(trimmed)) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(trimmed, origin);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function getChainRpcUrl(rpcUrl: string, chainId: number, localNode = isLocalNode): string {
+  const normalized = rpcUrl.replace(/\/+$/, "");
+  return localNode ? normalized : `${normalized}/${chainId}`;
+}
+
+export function resolveRpcConfig(input: RpcResolutionInput): RpcResolution {
+  const warnings: string[] = [];
+  const mode = input.mode;
+  const hostname = input.hostname ?? "";
+  const origin = input.origin ?? "http://localhost";
+  const envRpcUrl = input.envRpcUrl?.trim();
+  const localNode = mode === "local-node";
+  const isDevLike = mode === "development" || mode === "dev" || isDenoDeployHost(hostname);
+  const fallbackRpcUrls = localNode ? [] : [DEFAULT_MAINNET_RPC_URL];
+
+  const emitWarning = (message: string) => {
+    warnings.push(message);
+    input.warn?.(message);
+  };
+
+  if (envRpcUrl) {
+    if (isValidRpcUrl(envRpcUrl, origin)) {
+      return {
+        rpcUrl: envRpcUrl.replace(/\/+$/, ""),
+        fallbackRpcUrls: fallbackRpcUrls.filter((url) => url !== envRpcUrl.replace(/\/+$/, "")),
+        warnings,
+      };
+    }
+
+    emitWarning(`Ignoring invalid VITE_RPC_URL "${envRpcUrl}". Falling back to ${localNode ? LOCAL_NODE_RPC_URL : isDevLike ? DEFAULT_MAINNET_RPC_URL : PRODUCTION_RPC_PATH}.`);
+  }
+
+  if (localNode) {
+    return { rpcUrl: LOCAL_NODE_RPC_URL, fallbackRpcUrls, warnings };
+  }
+
+  if (isDevLike) {
+    return { rpcUrl: DEFAULT_MAINNET_RPC_URL, fallbackRpcUrls: [], warnings };
+  }
+
+  return { rpcUrl: PRODUCTION_RPC_PATH, fallbackRpcUrls, warnings };
+}
+
 const currentLocation = globalThis.location;
-export const RPC_URL =
-  import.meta.env.VITE_RPC_URL || (isDenoDeployHost(currentLocation?.hostname ?? "") ? "https://rpc.ubq.fi" : `${currentLocation?.origin ?? ""}/rpc`);
+
+export const rpcConfig = resolveRpcConfig({
+  envRpcUrl: import.meta.env.VITE_RPC_URL,
+  hostname: currentLocation?.hostname,
+  mode: import.meta.env.MODE,
+  origin: currentLocation?.origin,
+  warn: (message) => console.warn(message),
+});
+
+export const RPC_URL = rpcConfig.rpcUrl;
+export const RPC_FALLBACK_URLS = rpcConfig.fallbackRpcUrls;

--- a/src/utils/rpc-health.ts
+++ b/src/utils/rpc-health.ts
@@ -1,0 +1,102 @@
+import { isValidRpcUrl } from "../constants/config";
+
+type RpcHealthCheckOptions = {
+  expectedChainId?: number;
+  fetcher?: typeof fetch;
+  timeoutMs?: number;
+};
+
+export type RpcHealthStatus = "healthy" | "invalid-url" | "mismatched-chain" | "rpc-error" | "timeout" | "unreachable";
+
+export type RpcHealthResult = {
+  chainId?: number;
+  error?: string;
+  latencyMs: number;
+  ok: boolean;
+  status: RpcHealthStatus;
+  url: string;
+};
+
+type RpcResponse = {
+  error?: { message?: string };
+  result?: string;
+};
+
+export async function rpcHealthCheck(url: string, options: RpcHealthCheckOptions = {}): Promise<RpcHealthResult> {
+  const timeoutMs = options.timeoutMs ?? 1500;
+  const startedAt = Date.now();
+
+  if (!isValidRpcUrl(url)) {
+    return {
+      latencyMs: Date.now() - startedAt,
+      ok: false,
+      status: "invalid-url",
+      url,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const fetcher = options.fetcher ?? fetch;
+
+  try {
+    const response = await fetcher(url, {
+      body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "eth_chainId", params: [] }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return {
+        error: `HTTP ${response.status}`,
+        latencyMs: Date.now() - startedAt,
+        ok: false,
+        status: "unreachable",
+        url,
+      };
+    }
+
+    const payload = (await response.json()) as RpcResponse;
+    if (payload.error || !payload.result) {
+      return {
+        error: payload.error?.message ?? "Missing eth_chainId result",
+        latencyMs: Date.now() - startedAt,
+        ok: false,
+        status: "rpc-error",
+        url,
+      };
+    }
+
+    const chainId = Number.parseInt(payload.result, 16);
+    if (options.expectedChainId && chainId !== options.expectedChainId) {
+      return {
+        chainId,
+        error: `Expected chain ${options.expectedChainId}, got ${chainId}`,
+        latencyMs: Date.now() - startedAt,
+        ok: false,
+        status: "mismatched-chain",
+        url,
+      };
+    }
+
+    return {
+      chainId,
+      latencyMs: Date.now() - startedAt,
+      ok: true,
+      status: "healthy",
+      url,
+    };
+  } catch (error) {
+    const isTimeout = error instanceof Error && error.name === "AbortError";
+    return {
+      error: error instanceof Error ? error.message : "Unknown RPC health check failure",
+      latencyMs: Date.now() - startedAt,
+      ok: false,
+      status: isTimeout ? "timeout" : "unreachable",
+      url,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -1,6 +1,6 @@
 import { mainnet, anvil, type Chain } from "viem/chains";
-import { isLocalNode, RPC_URL } from "../constants/config";
-import { createConfig, http, injected, type Transport } from "wagmi";
+import { getChainRpcUrl, isLocalNode, RPC_FALLBACK_URLS, RPC_URL } from "../constants/config";
+import { createConfig, fallback, http, injected, type Transport } from "wagmi";
 
 export const supportedChains: readonly [Chain, ...Chain[]] = isLocalNode ? [mainnet, anvil] : [mainnet];
 
@@ -9,13 +9,16 @@ type TransportsMap = Record<ChainId, Transport>;
 
 // Anvil doesn't support URLs like http://localhost:8545/31337
 const transports = supportedChains.reduce<TransportsMap>((acc, chain) => {
-  // In local-node mode, use raw RPC_URL without chain ID suffix for ALL chains
-  // In production/dev mode, append chain ID
-  const rpcUrl = isLocalNode ? RPC_URL : `${RPC_URL}/${chain.id}`;
+  const rpcUrls = [RPC_URL, ...RPC_FALLBACK_URLS].map((rpcUrl) => getChainRpcUrl(rpcUrl, chain.id, isLocalNode));
+  const uniqueRpcUrls = [...new Set(rpcUrls)];
+  const rpcTransports = uniqueRpcUrls.map((rpcUrl) =>
+    http(rpcUrl, {
+      batch: isLocalNode ? false : true,
+      timeout: 2_000,
+    })
+  );
 
-  acc[chain.id] = http(rpcUrl, {
-    batch: isLocalNode ? false : true,
-  });
+  acc[chain.id] = rpcTransports.length === 1 ? rpcTransports[0] : fallback(rpcTransports);
   return acc;
 }, {} as TransportsMap);
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { isDenoDeployHost } from "../src/constants/config";
+import { DEFAULT_MAINNET_RPC_URL, getChainRpcUrl, isDenoDeployHost, isValidRpcUrl, resolveRpcConfig } from "../src/constants/config";
 
 describe("isDenoDeployHost", () => {
   it("matches Deno Deploy preview hostnames", () => {
@@ -11,5 +11,64 @@ describe("isDenoDeployHost", () => {
   it("does not match unrelated hostnames", () => {
     expect(isDenoDeployHost("stake.ubq.fi")).toBe(false);
     expect(isDenoDeployHost("localhost")).toBe(false);
+  });
+});
+
+describe("RPC config resolution", () => {
+  it("accepts valid VITE_RPC_URL values and adds the mainnet fallback only when useful", () => {
+    const resolved = resolveRpcConfig({
+      envRpcUrl: "https://example.com/rpc/",
+      mode: "prod",
+      warn: () => undefined,
+    });
+
+    expect(resolved.rpcUrl).toBe("https://example.com/rpc");
+    expect(resolved.fallbackRpcUrls).toEqual([DEFAULT_MAINNET_RPC_URL]);
+    expect(resolved.warnings).toEqual([]);
+  });
+
+  it("warns and falls back when VITE_RPC_URL is malformed", () => {
+    const warnings: string[] = [];
+    const resolved = resolveRpcConfig({
+      envRpcUrl: "not a url",
+      mode: "dev",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(resolved.rpcUrl).toBe(DEFAULT_MAINNET_RPC_URL);
+    expect(resolved.fallbackRpcUrls).toEqual([]);
+    expect(warnings[0]).toContain("Ignoring invalid VITE_RPC_URL");
+  });
+
+  it("keeps local-node mode on the raw Anvil endpoint without fallbacks", () => {
+    const resolved = resolveRpcConfig({
+      mode: "local-node",
+      warn: () => undefined,
+    });
+
+    expect(resolved.rpcUrl).toBe("http://localhost:8545");
+    expect(resolved.fallbackRpcUrls).toEqual([]);
+  });
+
+  it("uses the production proxy with a public fallback when no env URL exists", () => {
+    const resolved = resolveRpcConfig({
+      hostname: "stake.ubq.fi",
+      mode: "prod",
+      warn: () => undefined,
+    });
+
+    expect(resolved.rpcUrl).toBe("/rpc");
+    expect(resolved.fallbackRpcUrls).toEqual([DEFAULT_MAINNET_RPC_URL]);
+  });
+
+  it("builds chain-aware URLs except in local-node mode", () => {
+    expect(getChainRpcUrl("https://rpc.ubq.fi/", 1, false)).toBe("https://rpc.ubq.fi/1");
+    expect(getChainRpcUrl("http://localhost:8545/", 31337, true)).toBe("http://localhost:8545");
+  });
+
+  it("validates absolute and relative HTTP RPC URLs", () => {
+    expect(isValidRpcUrl("https://rpc.ubq.fi")).toBe(true);
+    expect(isValidRpcUrl("/rpc", "https://stake.ubq.fi")).toBe(true);
+    expect(isValidRpcUrl("ftp://rpc.ubq.fi")).toBe(false);
   });
 });

--- a/tests/rpc-health.test.ts
+++ b/tests/rpc-health.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+
+import { rpcHealthCheck } from "../src/utils/rpc-health";
+
+describe("rpcHealthCheck", () => {
+  it("returns healthy when eth_chainId responds", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      expectedChainId: 1,
+      fetcher: async () => Response.json({ id: 1, jsonrpc: "2.0", result: "0x1" }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("healthy");
+    expect(result.chainId).toBe(1);
+  });
+
+  it("reports invalid URLs before fetch", async () => {
+    const result = await rpcHealthCheck("not a url", {
+      fetcher: async () => Response.json({ result: "0x1" }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("invalid-url");
+  });
+
+  it("detects mismatched chain IDs", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      expectedChainId: 31337,
+      fetcher: async () => Response.json({ id: 1, jsonrpc: "2.0", result: "0x1" }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("mismatched-chain");
+    expect(result.error).toContain("Expected chain 31337");
+  });
+
+  it("surfaces JSON-RPC errors", async () => {
+    const result = await rpcHealthCheck("https://rpc.example", {
+      fetcher: async () => Response.json({ error: { message: "method unavailable" }, id: 1, jsonrpc: "2.0" }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe("rpc-error");
+    expect(result.error).toBe("method unavailable");
+  });
+});


### PR DESCRIPTION
Closes #9.

## Summary
- validate VITE_RPC_URL and warn before falling back
- add chain-aware fallback RPC transports with a 2s timeout
- add rpcHealthCheck() for eth_chainId health checks
- cover config resolution and health-check behavior with unit tests

## Validation
- npx tsc -p tsconfig.app.json
- npm run lint
- npx bun test
- npm run build